### PR TITLE
Attribute table tab closure and sort

### DIFF
--- a/widgets/AttributesTable.js
+++ b/widgets/AttributesTable.js
@@ -138,6 +138,9 @@ define([
             if (typeof options.closable == 'undefined'){
                 options.closable = true;
             }
+            if (typeof options.confirmClose == 'undefined'){
+                options.confirmClose = true;
+            }
             options.map = this.map;
             options.sidebarID = this.sidebarID;
 
@@ -156,7 +159,7 @@ define([
                     tab.startup();
                     tabs.addChild(tab);
                     tab.onClose = lang.hitch(tab, function () {
-                        var close = confirm('Do you really want to close this tab?');
+                        var close = this.confirmClose ? confirm('Do you really want to close this tab?') : true;
                         if (close && this.clearAll) {
                             this.clearAll();
                         }

--- a/widgets/AttributesTable.js
+++ b/widgets/AttributesTable.js
@@ -135,8 +135,10 @@ define([
             if (!options.id) {
                 options.id = 'attrTab-' + options.topicID;
             }
+            if (typeof options.closable == 'undefined'){
+                options.closable = true;
+            }
             options.map = this.map;
-            options.closable = true;
             options.sidebarID = this.sidebarID;
 
             if (this.useTabs) {

--- a/widgets/AttributesTable/README.md
+++ b/widgets/AttributesTable/README.md
@@ -93,6 +93,11 @@ define({
             // other instances of attributes table
             topicID: 'query',
 
+            // allow tabs to be closed
+            // confirm tab closure
+            closable: true,
+            confirmClose: true,
+
             queryOptions: {
                 // parameters for the query
                 queryParameters: {
@@ -225,7 +230,7 @@ gridOptions: {
     columns: [],
 
     /*
-        no sort
+        no sort, use sort: 'inherit' to use the order of the query results.
     */
     sort: [],
 

--- a/widgets/AttributesTable/_GridMixin.js
+++ b/widgets/AttributesTable/_GridMixin.js
@@ -251,6 +251,10 @@ define([
 
             // set the sort
             var sort = this.gridOptions.sort || [];
+            // sort === 'inherit'? use query result order
+            if (typeof sort === 'string' && sort.toLowerCase() === 'inherit'){
+                return;
+            }
             // no sort? use the first column
             if (sort.length < 1 && columns && columns.length > 0) {
                 sort = [


### PR DESCRIPTION
Allows a table config file to set whether a tab is closable and whether a confirmation dialog will appear on a tab closure. Also allows for a table to inherit the sort order from the query results. 
