### PR TITLE
filename configuration for Export widget

### DIFF
--- a/config/table.js
+++ b/config/table.js
@@ -84,7 +84,13 @@ define([], function () {
                 type: 'floating',
                 path: 'widgets/Export',
                 title: 'Export',
-                options: {}
+                options: {
+		    filename: function(){
+			var date = new Date();
+			
+			return "export_results_" + date.toLocaleDateString(); 
+		    }
+		}
             }
 		}
 	};

--- a/config/table.js
+++ b/config/table.js
@@ -85,6 +85,10 @@ define([], function () {
                 path: 'widgets/Export',
                 title: 'Export',
                 options: {
+		    // this option can be a string or a function that returns
+		    // a string.
+		    //
+		    // filename: 'my_results'
 		    filename: function(){
 			var date = new Date();
 			

--- a/widgets/Export.js
+++ b/widgets/Export.js
@@ -152,6 +152,14 @@ define([
             }
         },
 
+	getFileName: function(extension){
+	    if (this.filename){
+		return (typeof this.filename == "function" ? this.filename.call(this) + extension : this.filename + extension)
+	    } else{
+		return "result" + extension
+	    }
+	},
+
         /*******************************
         *  Export Function
         *******************************/
@@ -198,8 +206,8 @@ define([
                 bookSST: true,
                 type: 'binary'
             });
-
-            this.downloadFile(this.s2ab(wbout), 'application/vnd.ms-excel;', 'results.xlsx', true);
+    
+            this.downloadFile(this.s2ab(wbout), 'application/vnd.ms-excel;', this.getFileName('.xlsx'), true);
         },
 
         s2ab: function (s) {
@@ -223,7 +231,8 @@ define([
                 return;
             }
             var csv = window.XLSX.utils.sheet_to_csv(ws);
-            this.downloadFile(csv, 'text/csv;charset=utf-8;', 'results.csv', true);
+	    
+            this.downloadFile(csv, 'text/csv;charset=utf-8;', this.getFileName('.csv'), true);
         },
 
         createXLSX: function () {


### PR DESCRIPTION
I have added the option to configure the filename of the exported file. The filename property can be either undefined, a string, or a function that returns a string. 
