### PR TITLE
Adds the possibility to export to XLS (Office 2004 and below)

### DIFF
--- a/widgets/Export.js
+++ b/widgets/Export.js
@@ -50,6 +50,7 @@ define([
 
         excel: true,        // allow attributes to be exported to Excel
         csv: true,          // allow attributes to be exported to CSV
+        xlsExcel: true,		// allow attributes to be exported to Excel (XLS format)
 
         // spatial exports are not ready
         //geojson: false,     // allow features to be exported to GeoJSON
@@ -96,6 +97,7 @@ define([
             var options = [];
             var exportOptions = [
                 {value: 'excel', label: i18n.exportToExcel, type: 'attributes'},
+                {value: 'xlsExcel', label: i18n.exportToXlsExcel, type: 'attributes'},
                 {value: 'csv', label: i18n.exportToCSV, type: 'attributes'},
                 {value: 'geojson', label: i18n.exportToGeoJSON, type: 'features'},
                 {value: 'shapefile', label: i18n.exportToShapeFile, type: 'features'}
@@ -136,6 +138,9 @@ define([
             }
             if (typeof(options.csv) !== 'undefined') {
                 this.csv = options.csv;
+            }
+            if (options.xlsExcel !== undefined) {
+                this.xlsExcel = options.xlsExcel;
             }
             /*
             if (options.geojson !== undefined) {
@@ -179,6 +184,9 @@ define([
             case 'shapefile':
                 this.exportToShapeFile();
                 break;
+            case 'xlsExcel':
+                this.exportToXLS();
+                break;
             default:
                 break;
             }
@@ -187,6 +195,67 @@ define([
         /*******************************
         *  Excel/CSV Functions
         *******************************/
+
+        exportToXLS: function () {
+            var xlsContents = this.buildXLSContents();
+            if (!xlsContents) {
+                topic.publish('viewer/handleError', {
+                    widget: 'Export',
+                    error: '${i18n.errorExcel}'
+                });
+                return;
+            }
+
+            // To UTF-8
+            var uint8 = new Uint8Array(xlsContents.length);
+            for (var i = 0; i <  uint8.length; i++){
+                uint8[i] = xlsContents.charCodeAt(i);
+            }
+
+            this.downloadFile(uint8, 'application/vnd.ms-excel', 'results.xls', true);
+        },
+
+        buildXLSContents: function () {
+            var separator = '\t';
+            var carriageReturn = '\r';
+            var rows = this.grid.get('store').data;
+            var columns = this.grid.get('columns');
+
+            // Prepare formatted columns
+            var formattedColumns = columns.map(function(column) {
+            	if (column.exportable !== false && column.hidden !== true) {
+            		return column.label || column.field;
+            	}
+        	});
+
+            var formattedRows = [];
+
+            // Prepare rows' contents
+            array.forEach(rows, function (row) {
+            	var formattedRow = [];
+
+                array.forEach(columns, function (column) {
+                    if (column.exportable !== false && column.hidden !== true) {
+                        var field = column.field;
+                        var val = row[field];
+
+                        if (column.get) {
+                            val = column.get(row);
+                        }
+                        if (val === null || val === undefined) {
+                        	formattedRow.push('');
+                            return;
+                        }
+
+                        formattedRow.push(val.toString());
+                    }
+                });
+
+                formattedRows.push(formattedRow.join(separator));
+            });
+
+            return formattedColumns.join(separator) + carriageReturn + formattedRows.join(carriageReturn);
+        },
 
         exportToXLSX: function () {
             var ws = this.createXLSX();

--- a/widgets/Export.js
+++ b/widgets/Export.js
@@ -139,7 +139,7 @@ define([
             if (typeof(options.csv) !== 'undefined') {
                 this.csv = options.csv;
             }
-            if (options.xlsExcel !== undefined) {
+            if (options.xlsExcel !== 'undefined') {
                 this.xlsExcel = options.xlsExcel;
             }
             /*
@@ -208,7 +208,7 @@ define([
 
             // To UTF-8
             var uint8 = new Uint8Array(xlsContents.length);
-            for (var i = 0; i <  uint8.length; i++){
+            for (var i = 0; i < uint8.length; i++) {
                 uint8[i] = xlsContents.charCodeAt(i);
             }
 
@@ -222,17 +222,17 @@ define([
             var columns = this.grid.get('columns');
 
             // Prepare formatted columns
-            var formattedColumns = columns.map(function(column) {
-            	if (column.exportable !== false && column.hidden !== true) {
-            		return column.label || column.field;
-            	}
-        	});
+            var formattedColumns = columns.map(function (column) {
+                if (column.exportable !== false && column.hidden !== true) {
+                    return column.label || column.field;
+                }
+            });
 
             var formattedRows = [];
 
             // Prepare rows' contents
             array.forEach(rows, function (row) {
-            	var formattedRow = [];
+                var formattedRow = [];
 
                 array.forEach(columns, function (column) {
                     if (column.exportable !== false && column.hidden !== true) {
@@ -242,8 +242,8 @@ define([
                         if (column.get) {
                             val = column.get(row);
                         }
-                        if (val === null || val === undefined) {
-                        	formattedRow.push('');
+                        if (val === null || val === 'undefined') {
+                            formattedRow.push('');
                             return;
                         }
 

--- a/widgets/Export/nls/Export.js
+++ b/widgets/Export/nls/Export.js
@@ -14,6 +14,7 @@ define({
         'errorExcel': 'Could not create Excel Spreadsheet',
         'errorCSV': 'Could not create CSV File',
         'errorGeoJSON': 'Could not create GeoJSON File',
-        'errorShapeFile': 'Could not create Shapefile'
+        'errorShapeFile': 'Could not create Shapefile',
+        'exportToXlsExcel': 'Export To Excel (XLS)'
     }
 });


### PR DESCRIPTION
Some customers complained that they weren't able to open the generated XLSX file because, in the case, they have Office 2003.
After digging a while, I've seen [Table Export](http://www.clarketravis.com/tableexport/), [js-xlsx](https://github.com/SheetJS/js-xlsx) and [FileSaver](https://github.com/eligrey/FileSaver.js/) to elaborate something that they could enjoy.
So here it is: a new option to export XLS which is, actually, a tabulated text file that your old Excel doesn't complain to open. I found this better then to implement a custom Java/whatever webservice just to serve XLS files.
