### PR TITLE
Adds the possibility to include layer's layerDefinitions in QueryTask

### DIFF
--- a/widgets/AttributesTable/_QueryTaskMixin.js
+++ b/widgets/AttributesTable/_QueryTaskMixin.js
@@ -60,8 +60,8 @@ define([
                 outStatistics: null,
                 pixelSize: null,
                 relationParam: null,
-                spatialRelationship: Query.SPATIAL_REL_INTERSECTS
-
+                spatialRelationship: Query.SPATIAL_REL_INTERSECTS,
+                includeLayerDefinitions: false
             },
 
             // provide the parameters if there is a spatial query linked from a table/database query
@@ -435,6 +435,18 @@ define([
                             url = layer.url + '/' + qp.sublayerID;
                         } else if (layer.visibleLayers && layer.visibleLayers.length === 1) {
                             url = layer.url + '/' + layer.visibleLayers[0];
+                        }
+                    }
+                    
+                    if (qp.includeLayerDefinitions && layer.layerDefinitions) {
+                        var whereByLayerDef = layer.layerDefinitions[qp.sublayerID];
+
+                        if (whereByLayerDef) {
+                            if (qp.where) {
+                                qp.where = '(' + whereByLayerDef + ') AND (' + qp.where + ')';
+                            } else {
+                                qp.where = whereByLayerDef;
+                            }
                         }
                     }
                 }

--- a/widgets/AttributesTable/_QueryTaskMixin.js
+++ b/widgets/AttributesTable/_QueryTaskMixin.js
@@ -428,9 +428,14 @@ define([
             if (!url && qp.layerID) {
                 var layer = this.map.getLayer(qp.layerID);
                 if (layer) {
+                    var whereByLayerDef;
                     if (layer.declaredClass === 'esri.layers.FeatureLayer') { // Feature Layer
+                        whereByLayerDef = layer.getDefinitionExpression();
+                        
                         url = layer.url;
                     } else if (layer.declaredClass === 'esri.layers.ArcGISDynamicMapServiceLayer') { // Dynamic Layer
+                        whereByLayerDef = layer.layerDefinitions[qp.sublayerID];
+                        
                         if (qp.sublayerID !== null) {
                             url = layer.url + '/' + qp.sublayerID;
                         } else if (layer.visibleLayers && layer.visibleLayers.length === 1) {
@@ -438,15 +443,11 @@ define([
                         }
                     }
                     
-                    if (qp.includeLayerDefinitions && layer.layerDefinitions) {
-                        var whereByLayerDef = layer.layerDefinitions[qp.sublayerID];
-
-                        if (whereByLayerDef) {
-                            if (qp.where) {
-                                qp.where = '(' + whereByLayerDef + ') AND (' + qp.where + ')';
-                            } else {
-                                qp.where = whereByLayerDef;
-                            }
+                    if (whereByLayerDef && qp.includeLayerDefinitions) {
+                        if (qp.where) {
+                            qp.where = '(' + whereByLayerDef + ') AND (' + qp.where + ')';
+                        } else {
+                            qp.where = whereByLayerDef;
                         }
                     }
                 }


### PR DESCRIPTION
This PR is related to [issue 74](https://github.com/tmcgee/cmv-widgets/issues/74).

To test:

_config/searchWidget.js_

``` javascript
(...)
layers : [{
        name : 'Damage Assessment',
        expression : '', // additional where expression applied to all queries
        idProperty : 'objectid',
        queryParameters : {
            type : 'spatial', // spatial, relationship, table or database
            layerID : 'DamageAssessment', // from operational layers
            sublayerID : 0,
            outFields : ['*'],
            includeLayerDefinitions : true //NEW LINE TO TEST
        },
        (...)
```

_config/search.js_

``` javascript
define([
    'esri/config',
    'esri/tasks/GeometryService',
    'esri/layers/ImageParameters'
], function (esriConfig, GeometryService, ImageParameters) {

    esriConfig.defaults.geometryService = new GeometryService('https://tasks.arcgisonline.com/ArcGIS/rest/services/Geometry/GeometryServer');

    var imageParameters = new ImageParameters();
    imageParameters.format = 'png32';

    // <NEW TO TEST>
    var imageParametersTest = new ImageParameters();
    imageParametersTest.format = 'png32';
    imageParametersTest['layerDefinitions'][0] = 'typdamage = \'Affected\'';
    // </NEW TO TEST>
    (...)
```

and...

``` javascript
(...)
operationalLayers : [
    (...) {
        type : 'dynamic',
        url : 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/MapServer',
        title : 'Damage Assessment',
        options : {
            id : 'DamageAssessment',
            opacity : 1.0,
            visible : true,
            imageParameters : imageParametersTest // MODIFIED TO TEST
        }
    },

    // OR

    // <NEW TO TEST WITH FEATURES>
    {
        type : 'feature',
        url : ...,
        title : 'PARADAS',
        options : {
            id : 'paradas',
            opacity : 1.0,
            visible : false,
            outFields : ['*'],
            mode : 1,
            showLabels : true,
            definitionExpression : 'PISO = \'Concreto\''
        },
        identifyLayerInfos : {
            layerIds : [0]
        },
        layerControlLayerInfos : {
            swipe : true,
            metadataUrl : false,
            expanded : false
        }
    }
    // </NEW TO TEST WITH FEATURES>
],
(...)
```
