### PR TITLE
Adding support for maxAllowableOffset option

### DIFF
--- a/widgets/ZoomToFeature.js
+++ b/widgets/ZoomToFeature.js
@@ -68,6 +68,9 @@ define([
         // where clause to filter the results
         where: '1=1',
 
+        // maximum allowable offset to be used for generalizing geometries returned by the query operation
+        maxAllowableOffset: null,
+
         // Spatial Reference. uses the map's spatial reference if none provided
         spatialReference: null,
 
@@ -220,6 +223,9 @@ define([
             query.orderByFields = [this.field];
             query.where = this.where;
             query.returnGeometry = true;
+            if (this.maxAllowableOffset) {
+                query.maxAllowableOffset = this.maxAllowableOffset;
+            }
             //query.returnDistinctValues = true;
             query.outSpatialReference = {
                 wkid: this.spatialReference


### PR DESCRIPTION
This is a really simple change, but which has made a big difference on our site. We've got some large, detailed features (counties, water management districts) with detailed geometry. Adding the maxAllowableOffset to the query improved the initial loading of the widget from ~50 seconds to ~4 seconds.